### PR TITLE
Add diagrams to explain hawk/dove risk attitudes

### DIFF
--- a/simulatingrisk/hawkdove/README.md
+++ b/simulatingrisk/hawkdove/README.md
@@ -44,6 +44,30 @@ Each player on a lattice (grid in Mesa):
 
 ## Payoffs and risk attitudes
 
+This game has a discrete set of options instead of probability, so instead of defining `r` as a value between 0.0 and 1.0, we use discrete values based on the choices. For the game that includes diagonal neighbors when agents play all neighbors:
+
+<table>
+   <tr><td></td></td><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td></tr>
+   <tr>
+      <td>Plays H when:</td>
+      <td>$\geq1$ D</td>
+      <td>$\geq2$ D</td>
+      <td>$\geq3$ D</td>
+      <td>$\geq4$ D</td>
+      <td>$\geq5$ D</td>
+      <td>$\geq6$ D</td>
+      <td>$\geq7$ D</td>
+      <td>$\geq8$ D</td>
+      <td>all D</td>
+   </tr>
+   <tr><td></td>
+      <td colspan="4">risk seeking</td>
+      <td>EU maximizer<br>(risk neutral)</td>
+   <td colspan="4">risk avoidant</td>
+   </tr>
+</table>
+
+
 An REU maximizer will play HAWK when
 ```math
 r(p) > \frac{(D,H)-(H,H)}{(H,D)-(D,D)}

--- a/simulatingrisk/hawkdove/README.md
+++ b/simulatingrisk/hawkdove/README.md
@@ -58,7 +58,7 @@ This game has a discrete set of options instead of probability, so instead of de
       <td>$\geq6$ D</td>
       <td>$\geq7$ D</td>
       <td>$\geq8$ D</td>
-      <td>all D</td>
+      <td>never</td>
    </tr>
    <tr><td></td>
       <td colspan="4">risk seeking</td>

--- a/simulatingrisk/hawkdove/README.md
+++ b/simulatingrisk/hawkdove/README.md
@@ -76,5 +76,19 @@ In other words, when $r(p) > 0.52$. An EU maximizer, with $r(p) = p$, will play 
 
 Payoffs were chosen to avoid the case in which two choices had equal expected utility for some number of neighbors. For example, if the payoff of $(D,D)$ was $(2,2)$, then at $p = 0.5$ (4 of 8 neighbors), then EU maximizers would be indifferent between HAWK and DOVE; in this case, no r-value would correspond to EU maximization, since $r = 4$ strictly prefers DOVE and $r = 3$ strictly prefers HAWK.
 
+Another way to visualize the risk attitudes and choices in this game is this table, which shows when agents will play Hawk or Dove based on their risk attitudes (going down on the left side) and the number of neighbors playing Dove (across the top).
 
+<table>
+   <tr><td colspan="2"></td><td colspan="9"># of neighors playing DOVE</td></tr>
+   <tr><td><th>r</th><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td></tr>
+   <tr><td rowspan="4">risk seeking</td><th>0</th><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><th>1</th><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><th>2</th><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><th>3</th><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><td>neutral</td></td><th>4</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><td rowspan="4">risk avoidant</td><th>5</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><th>6</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td></tr>
+   <tr><th>7</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td></tr>
+   <tr><th>8</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td></tr>
+</table>
 

--- a/simulatingrisk/hawkdove/README.md
+++ b/simulatingrisk/hawkdove/README.md
@@ -47,9 +47,9 @@ Each player on a lattice (grid in Mesa):
 This game has a discrete set of options instead of probability, so instead of defining `r` as a value between 0.0 and 1.0, we use discrete values based on the choices. For the game that includes diagonal neighbors when agents play all neighbors:
 
 <table>
-   <tr><td></td></td><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td></tr>
+   <tr><th>r</th></th><th>0</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th><th>6</th><th>7</th><th>8</th></tr>
    <tr>
-      <td>Plays H when:</td>
+      <th>Plays H when:</th>
       <td>$\geq1$ D</td>
       <td>$\geq2$ D</td>
       <td>$\geq3$ D</td>
@@ -79,7 +79,7 @@ Payoffs were chosen to avoid the case in which two choices had equal expected ut
 Another way to visualize the risk attitudes and choices in this game is this table, which shows when agents will play Hawk or Dove based on their risk attitudes (going down on the left side) and the number of neighbors playing Dove (across the top).
 
 <table>
-   <tr><td colspan="2"></td><td colspan="9"># of neighors playing DOVE</td></tr>
+   <tr><td colspan="2"></td><th colspan="9"># of neighors playing DOVE</thr></tr>
    <tr><td><th>r</th><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td></tr>
    <tr><td rowspan="4">risk seeking</td><th>0</th><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
    <tr><th>1</th><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>

--- a/simulatingrisk/hawkdove/README.md
+++ b/simulatingrisk/hawkdove/README.md
@@ -17,7 +17,7 @@ We want to know: what happens when different people have _different_ risk-attitu
 
 GAME: Hawk-Dove with risk-attitudes
 
-Players arranged on a lattice [try both 4 neighbors (AYBD) and 8 neighbors (XYZABCDE)]
+Players arranged on a lattice [options for both 4 neighbors (AYBD) and 8 neighbors (XYZABCDE)]
 
 | | | |
 |-|-|-|
@@ -33,16 +33,24 @@ Players arranged on a lattice [try both 4 neighbors (AYBD) and 8 neighbors (XYZA
    - If I play HAWK and neighbor plays HAWK: 0
  
 Each player on a lattice (grid in Mesa):
-- Has parameter `r` [from 0 to 8, or 0 to 4 for four neighbors]
-- Let `d` be the number of neighbors who played DOVE during the previous round. If `d > r`, then play HAWK. Otherwise play DOVE. (Agents who are risk-avoidant only play HAWK if there are a lot of doves around them. More risk-avoidance requires a higher number of doves to get an agent to play HAWK.)
-- The proportion of neighbors who play DOVE corresponds to your probability of encountering a DOVE when playing a randomly-selected neighbor. The intended interpretation is that you maximize REU for this probability of your opponent playing DOVE. Thus, r corresponds to the probability above which playing HAWK maximizes REU.
-- An REU maximizer will play HAWK when r(p) > [(D,H)-(H,H)]/[(H,D)-(D,D)] ; in other words, when r(p) > 0.52. An EU maximizer, with r(p) = p, will play HAWK when p > 0.52, e.g., when more than 4 out of 8 neighbors play DOVE. Thus, r = 4 corresponds to risk-neutrality (EU maximization), r < 4 corresponds to risk-inclination, and r > 4 corresponds to risk-avoidance.
-- Payoffs were chosen to avoid the case in which two choices had equal expected utility for some number of neighbors. For example, if the payoff of (D,D) was (2,2), then at p = 0.5 (4 of 8 neighbors), then EU maximizers would be indifferent between HAWK and DOVE; in this case, no r-value would correspond to EU maximization, since r = 4 strictly prefers DOVE and r = 3 strictly prefers HAWK.
-  
+- Has parameter $r$ [from 0 to 8, or 0 to 4 for four neighbors]
+- Let `d` be the number of neighbors who played DOVE during the previous round. If $d > r$, then play HAWK. Otherwise play DOVE. (Agents who are risk-avoidant only play HAWK if there are a lot of doves around them. More risk-avoidance requires a higher number of doves to get an agent to play HAWK.)
+- The proportion of neighbors who play DOVE corresponds to your probability of encountering a DOVE when playing a randomly-selected neighbor. The intended interpretation is that you maximize REU for this probability of your opponent playing DOVE. Thus, $r$ corresponds to the probability above which playing HAWK maximizes REU.
   - Choice for the first round could be randomly determined, or add parameters to see how initial conditions matter?
   - [OR VARY FIRST ROUND: what proportion starts as HAWK
-    - [Who is a HAWK and who is a DOVE is randomly determined; proportion set at the beginning of each simulation. E.g. 30% are HAWKS; if we have 100 players, then each player has a 30% chance of being HAWK]
-   - Call this initial parameter HAWK-ODDS
+    - Who is a HAWK and who is a DOVE is randomly determined; proportion set at the beginning of each simulation. E.g. 30% are HAWKS; if we have 100 players, then each player has a 30% chance of being HAWK; 
+   - Call this initial parameter HAWK-ODDS; default is 50/50
+
+
+## Payoffs and risk attitudes
+
+An REU maximizer will play HAWK when
+```math
+r(p) > \frac{(D,H)-(H,H)}{(H,D)-(D,D)}
+```
+In other words, when $r(p) > 0.52$. An EU maximizer, with $r(p) = p$, will play HAWK when $p > 0.52$, e.g., when more than 4 out of 8 neighbors play DOVE. Thus, $r = 4$ corresponds to risk-neutrality (EU maximization), $r < 4$ corresponds to risk-inclination, and $r > 4$ corresponds to risk-avoidance.
+
+Payoffs were chosen to avoid the case in which two choices had equal expected utility for some number of neighbors. For example, if the payoff of $(D,D)$ was $(2,2)$, then at $p = 0.5$ (4 of 8 neighbors), then EU maximizers would be indifferent between HAWK and DOVE; in this case, no r-value would correspond to EU maximization, since $r = 4$ strictly prefers DOVE and $r = 3$ strictly prefers HAWK.
 
 
 


### PR DESCRIPTION
@LaraBuchak I've updated the hawk/dove readme to include tables representing the two diagrams you sketched out in our last meeting.

I also applied math formatting to the equation you added in your last set of edits explaining REU and 2.1 dove payoff.

Please confirm I haven't messed up anything with your math formulas and that the two tables convey what you intended with the diagrams you sketched out.

You can see how it looks here:
https://github.com/Princeton-CDH/simulating-risk/tree/hawkdove-reu-description/simulatingrisk/hawkdove#readme

