### PR TITLE
update hawk/dove with options for different risk attitude distributions

### DIFF
--- a/simulatingrisk/hawkdovemulti/app.py
+++ b/simulatingrisk/hawkdovemulti/app.py
@@ -23,6 +23,12 @@ jupyterviz_params_var.update(
             "values": ["none", "adopt", "average"],
             "description": "If and how agents update their risk level",
         },
+        "risk_distribution": {
+            "type": "Select",
+            "value": "uniform",
+            "values": HawkDoveMultipleRiskModel.risk_distribution_options,
+            "description": "Distribution for initial risk attitudes",
+        },
         "adjust_every": {
             "label": "Adjustment frequency (# rounds)",
             "type": "SliderInt",
@@ -42,7 +48,7 @@ jupyterviz_params_var.update(
             "type": "Select",
             "label": "Adjustment comparison period",
             "value": "recent",
-            "values": ["recent", "total"],
+            "values": HawkDoveMultipleRiskModel.supported_adjust_payoffs,
             "description": "Compare recent payoff (since last adjustment "
             + "round) or total (cumulative from start) when adjusting risk attitudes",
         },


### PR DESCRIPTION
ref #18 

- new model parameter with list of supported distributions
- new method to generate agent risk level based on configured distribution
- configure the new option to be available in the solara interface


The easiest way to see how it's working is to run the model with solara and try switching between the different distributions, then run for one step to see the bar chart of the number of agents for each risk attitude. Works better on larger grids.


(temporarily comparing against adjust payoff branch to isolate diffs, since this code is forked from that branch)