### PR TITLE
Update hawk/dove game risk attitudes to include both endpoints

### DIFF
--- a/simulatingrisk/hawkdove/README.md
+++ b/simulatingrisk/hawkdove/README.md
@@ -81,14 +81,15 @@ Another way to visualize the risk attitudes and choices in this game is this tab
 
 <table>
    <tr><td colspan="2"></td><th colspan="9"># of neighors playing DOVE</thr></tr>
-   <tr><td><th>r</th><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td><td>9</td></tr>
-   <tr><td rowspan="4">risk seeking</td><th>0</th><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
-   <tr><th>1</th><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
-   <tr><th>2</th><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
-   <tr><th>3</th><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
-   <tr><td>neutral</td></td><th>4</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
-   <tr><td rowspan="4">risk avoidant</td><th>5</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td></tr>
-   <tr><th>6</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td></tr>
-   <tr><th>7</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td></tr>
-   <tr><th>8</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td></tr>
+   <tr><td><th>r</th><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td></tr>
+   <tr><td rowspan="4">risk seeking</td><th>0</th><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><th>1</th><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><th>2</th><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><th>3</th><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><td rowspan="2">neutral</td></td><th>4</th><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><th>5</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><td rowspan="4">risk avoidant</td><th>6</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td></tr>
+   <tr><th>7</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td></tr>
+   <tr><th>8</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td></tr>
+   <tr><th>9</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td></tr>
 </table>

--- a/simulatingrisk/hawkdove/README.md
+++ b/simulatingrisk/hawkdove/README.md
@@ -9,7 +9,7 @@ This is a variant of the Hawk/Dove Game: https://en.wikipedia.org/wiki/Chicken_(
 | | H | D|
 |-|-|-|
 | H | 0, 0 | 3, 1|
-| D |1, 3| 2.1, 2.1|
+| D |1, 3| 2, 2|
 
 BACKGROUND: An unpublished paper by Simon Blessenohl shows that the equilibrium in this game is different for EU maximizers than for REU maximizers (all with the same risk-attitude), and that REU maximizers do better as a population (basically, play DOVE more often)
 
@@ -28,18 +28,17 @@ Players arranged on a lattice [options for both 4 neighbors (AYBD) and 8 neighbo
 - Payoffs are determined as follows:
    -  Look at what each neighbor did, then:
    -  If I play HAWK and neighbor plays DOVE: 3
-   -  If I play DOVE and neighbor plays DOVE: 2.1
+   -  If I play DOVE and neighbor plays DOVE: 2
    -  If I play DOVE and neighbor plays HAWK: 1
    - If I play HAWK and neighbor plays HAWK: 0
 
 Each player on a lattice (grid in Mesa):
-- Has parameter $r$ [from 0 to 8]
-- Let `d` be the number of neighbors who played DOVE during the previous round. If $d > r$, then play HAWK. Otherwise play DOVE. (Agents who are risk-avoidant only play HAWK if there are a lot of doves around them. More risk-avoidance requires a higher number of doves to get an agent to play HAWK.)
+- Has parameter $r$ [from 0 to 9]
+- Let `d` be the number of neighbors who played DOVE during the previous round. If $d >= r$, then play HAWK. Otherwise play DOVE. (Agents who are risk-avoidant only play HAWK if there are a lot of doves around them. More risk-avoidance requires a higher number of doves to get an agent to play HAWK.)
 - The proportion of neighbors who play DOVE corresponds to your probability of encountering a DOVE when playing a randomly-selected neighbor. The intended interpretation is that you maximize REU for this probability of your opponent playing DOVE. Thus, $r$ corresponds to the probability above which playing HAWK maximizes REU.
-  - Choice for the first round could be randomly determined, or add parameters to see how initial conditions matter?
-  - [OR VARY FIRST ROUND: what proportion starts as HAWK
+  - Choice of play for the first round:
     - Who is a HAWK and who is a DOVE is randomly determined; proportion set at the beginning of each simulation. E.g. 30% are HAWKS; if we have 100 players, then each player has a 30% chance of being HAWK;
-   - Call this initial parameter HAWK-ODDS; default is 50/50
+   - This initial parameter is called HAWK-ODDS; default is 50/50
 
 
 ## Payoffs and risk attitudes
@@ -47,9 +46,10 @@ Each player on a lattice (grid in Mesa):
 This game has a discrete set of options instead of probability, so instead of defining `r` as a value between 0.0 and 1.0, we use discrete values based on the choices. For the game that includes diagonal neighbors when agents play all neighbors:
 
 <table>
-   <tr><th>r</th></th><th>0</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th><th>6</th><th>7</th><th>8</th></tr>
+   <tr><th>r</th></th><th>0</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th><th>6</th><th>7</th><th>8</th><th>9</th></tr>
    <tr>
       <th>Plays H when:</th>
+      <td>never</td>      
       <td>$\geq1$ D</td>
       <td>$\geq2$ D</td>
       <td>$\geq3$ D</td>
@@ -62,6 +62,7 @@ This game has a discrete set of options instead of probability, so instead of de
    </tr>
    <tr><td></td>
       <td colspan="4">risk seeking</td>
+      <td>EU maximizer<br>(risk neutral)</td>      
       <td>EU maximizer<br>(risk neutral)</td>
    <td colspan="4">risk avoidant</td>
    </tr>
@@ -80,7 +81,7 @@ Another way to visualize the risk attitudes and choices in this game is this tab
 
 <table>
    <tr><td colspan="2"></td><th colspan="9"># of neighors playing DOVE</thr></tr>
-   <tr><td><th>r</th><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td></tr>
+   <tr><td><th>r</th><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td><td>9</td></tr>
    <tr><td rowspan="4">risk seeking</td><th>0</th><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
    <tr><th>1</th><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>
    <tr><th>2</th><td>D</td><td>D</td><td>D</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td><td>H</td></tr>

--- a/simulatingrisk/hawkdove/model.py
+++ b/simulatingrisk/hawkdove/model.py
@@ -119,7 +119,7 @@ class HawkDoveAgent(mesa.Agent):
             #   (any risk is acceptable).
             # agent with r = max should always take the safe option
             #   (no risk is acceptable)
-            if self.proportional_num_dove_neighbors > self.risk_level:
+            if self.proportional_num_dove_neighbors >= self.risk_level:
                 self.choice = Play.HAWK
             else:
                 self.choice = Play.DOVE
@@ -138,7 +138,7 @@ class HawkDoveAgent(mesa.Agent):
     def payoff(self, other):
         """
         If I play HAWK and neighbor plays DOVE: 3
-        If I play DOVE and neighbor plays DOVE: 2.1
+        If I play DOVE and neighbor plays DOVE: 2
         If I play DOVE and neighbor plays HAWK: 1
         If I play HAWK and neighbor plays HAWK: 0
         """
@@ -149,7 +149,7 @@ class HawkDoveAgent(mesa.Agent):
                 return 0
         elif self.choice == Play.DOVE:
             if other.choice == Play.DOVE:
-                return 2.1
+                return 2
             if other.choice == Play.HAWK:
                 return 1
 
@@ -187,9 +187,9 @@ class HawkDoveModel(mesa.Model):
     #: supported neighborhood sizes
     neighborhood_sizes = {4, 8, 24}
     #: minimu risk level
-    min_risk_level = 0  # TODO: allow -1 ?
+    min_risk_level = 0
     #: maximum risk level allowed
-    max_risk_level = 8
+    max_risk_level = 9
 
     def __init__(
         self,

--- a/simulatingrisk/hawkdovemulti/model.py
+++ b/simulatingrisk/hawkdovemulti/model.py
@@ -291,8 +291,11 @@ class HawkDoveMultipleRiskModel(HawkDoveModel):
         #  Risk-avoidant (RA): r = 6, 7, 8
         total = {
             "risk_inclined": risk_counts[0] + risk_counts[1] + risk_counts[2],
-            "risk_moderate": risk_counts[3] + risk_counts[4] + risk_counts[5],
-            "risk_avoidant": risk_counts[6] + risk_counts[7] + risk_counts[8],
+            "risk_moderate": risk_counts[3]
+            + risk_counts[4]
+            + risk_counts[5]
+            + risk_counts[6],
+            "risk_avoidant": risk_counts[7] + risk_counts[8] + risk_counts[9],
         }
         # for each group, calculate percent of agents in that category
         total_agents = len(self.schedule.agents)

--- a/tests/test_hawkdove.py
+++ b/tests/test_hawkdove.py
@@ -144,10 +144,10 @@ def test_agent_choose():
         assert agent.choice == Play.HAWK
 
         # risk level three with 3 doves will play dove
-        # (strictly greater comparison)
+        # (greater than or equal)
         agent.risk_level = 3
         agent.choose()
-        assert agent.choice == Play.DOVE
+        assert agent.choice == Play.HAWK
 
         # agent with risk level 8 will always play dove
         agent.risk_level = 8
@@ -159,19 +159,19 @@ def test_proportional_num_dove_neighbors():
     model = HawkDoveSingleRiskModel(4, agent_risk_level=3)
     agent = HawkDoveSingleRiskAgent(1, model)
 
-    ## equal play/observed; scales to 8 (risk level range)
+    ## equal play/observed; scales to 9 (risk level range)
     model.observed_neighborhood = 4
     with patch.object(HawkDoveAgent, "num_dove_neighbors", 3):
-        assert agent.proportional_num_dove_neighbors == 6
+        assert agent.proportional_num_dove_neighbors == 7
 
     model.observed_neighborhood = 8
     with patch.object(HawkDoveAgent, "num_dove_neighbors", 5):
-        assert agent.proportional_num_dove_neighbors == 5
+        assert agent.proportional_num_dove_neighbors == 6
 
     # observe more than 8
     model.observed_neighborhood = 24
     with patch.object(HawkDoveAgent, "num_dove_neighbors", 20):
-        assert agent.proportional_num_dove_neighbors == 7
+        assert agent.proportional_num_dove_neighbors == 8
 
 
 def test_agent_choose_when_observe_play_differ():
@@ -209,7 +209,7 @@ def test_agent_play():
 
 def test_agent_payoff():
     # If I play HAWK and neighbor plays DOVE: 3
-    # If I play DOVE and neighbor plays DOVE: 2.1
+    # If I play DOVE and neighbor plays DOVE: 2
     # If I play DOVE and neighbor plays HAWK: 1
     # If I play HAWK and neighbor plays HAWK: 0
 
@@ -230,5 +230,5 @@ def test_agent_payoff():
     # if both play dove, payoff is two for both
     agent.choice = Play.DOVE
     other_agent.choice = Play.DOVE
-    assert agent.payoff(other_agent) == 2.1
-    assert other_agent.payoff(agent) == 2.1
+    assert agent.payoff(other_agent) == 2
+    assert other_agent.payoff(agent) == 2

--- a/tests/test_hawkdovemulti.py
+++ b/tests/test_hawkdovemulti.py
@@ -94,11 +94,11 @@ def test_population_risk_category():
     assert model.population_risk_category == RiskState.c2
 
     # majority risk moderate
-    model.schedule.agents = [Mock(risk_level=4), Mock(risk_level=3), Mock(risk_level=5)]
+    model.schedule.agents = [Mock(risk_level=4), Mock(risk_level=5), Mock(risk_level=6)]
     assert model.population_risk_category == RiskState.c7
 
     # majority risk avoidant
-    model.schedule.agents = [Mock(risk_level=6), Mock(risk_level=7), Mock(risk_level=8)]
+    model.schedule.agents = [Mock(risk_level=7), Mock(risk_level=8), Mock(risk_level=9)]
     assert model.population_risk_category == RiskState.c12
 
 


### PR DESCRIPTION
- increase max risk level to 9
- change comparison from > to >= when choosing play
- change payoff back from 2.1 to 2
- update category grouping (0,1,2; 3,4,5,6; 7,8,9)
- update game description in readme