### PR TITLE
Document hawk/dove convergence logic + collect model status (running/convergence)

### DIFF
--- a/simulatingrisk/hawkdove/README.md
+++ b/simulatingrisk/hawkdove/README.md
@@ -94,3 +94,13 @@ Another way to visualize the risk attitudes and choices in this game is this tab
    <tr><th>8</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>H</td></tr>
    <tr><th>9</th><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td><td>D</td></tr>
 </table>
+
+## Convergence
+
+The model is configured to stop automatically when it has stabilized. Convergence is based on a stable rolling average of the percent of agents in the simulation playing hawk.
+
+A rolling average of the percent of agents playing hawk is calculated every round based on the percent for the last **30** rounds.  The rolling average is not calculated until after at least **15** rounds.
+
+When we have collected the rolling average for at least **15** rounds and the last **30** rolling averages are the same when rounded to 2 percentage points, we consider the simulation converged.
+
+

--- a/simulatingrisk/hawkdove/app.py
+++ b/simulatingrisk/hawkdove/app.py
@@ -81,5 +81,6 @@ page = JupyterViz(
     agent_portrayal=agent_portrayal,
     space_drawer=draw_hawkdove_agent_space,
 )
+
 # required to render the visualization with Jupyter/Solara
 page

--- a/simulatingrisk/hawkdovemulti/batch_run.py
+++ b/simulatingrisk/hawkdovemulti/batch_run.py
@@ -64,7 +64,7 @@ def run_hawkdovemulti_model(args):
 
 
 def batch_run(
-    params, iterations, number_processes, max_steps, progressbar, file_prefix
+    params, iterations, number_processes, max_steps, progressbar, file_prefix, max_runs
 ):
     param_combinations = _make_model_kwargs(params)
     total_param_combinations = len(param_combinations)
@@ -82,6 +82,10 @@ def batch_run(
         for iteration in range(iterations):
             runs_list.append((run_id, iteration, params, max_steps))
             run_id += 1
+
+    # if maximum runs is specified, truncate the list of run arguments
+    if max_runs:
+        runs_list = runs_list[:max_runs]
 
     # collect data in a directory for this model
     data_dir = os.path.join("data", "hawkdovemulti")
@@ -169,6 +173,13 @@ def main():
         help="Prefix for data filenames (no prefix by default)",
         default="",
     )
+    parser.add_argument(
+        "--max-runs",
+        help="Stop after the specified number of runs "
+        + "(for development/troubleshooting)",
+        type=int,
+        default=None,
+    )
     # may want to add an option to configure output dir
 
     args = parser.parse_args()
@@ -179,6 +190,7 @@ def main():
         args.max_steps,
         args.progress,
         args.file_prefix,
+        args.max_runs,
     )
 
 


### PR DESCRIPTION
- include write up of convergence logic in hawk/dove readme
- include status (running/converged) in model data collection so we can make sure we're analyzing runs where the model stabilized
- add an option to limit total batch runs for convenience 
- make agent data collection optional in batch run script


@LaraBuchak : please review the write up of the convergence logic
- is it clear enough?
- are you ok with these numbers (30 and 15 for rolling window and minimum window)?

here's a more readable version of the convergence logic in the hawk/dove model readme: https://github.com/Princeton-CDH/simulating-risk/tree/doc-convergence/simulatingrisk/hawkdove#convergence