### PR TITLE
Simulation updates

### DIFF
--- a/simulatingrisk/hawkdove/model.py
+++ b/simulatingrisk/hawkdove/model.py
@@ -201,6 +201,8 @@ class HawkDoveModel(mesa.Model):
     rolling_window = 30
     #: minimum size before calculating rolling average
     min_window = 15
+    #: minimum steps before model can converge
+    min_steps_converge = 30
     #: class to use when initializing agents
     agent_class = HawkDoveAgent
     #: supported neighborhood sizes
@@ -320,6 +322,9 @@ class HawkDoveModel(mesa.Model):
 
     @property
     def rolling_percent_hawk(self):
+        # rolling average of percent hawk, included in data collection
+        # only generated after a defined minimum window
+
         # make sure we have enough values to check
         if len(self.recent_percent_hawk) > self.min_window:
             rolling_phawk = statistics.mean(self.recent_percent_hawk)
@@ -334,6 +339,10 @@ class HawkDoveModel(mesa.Model):
         # within our rolling window, return true
         # - currently checking for single value;
         #  could allow for a small amount variation if necessary
+
+        # don't check before a minimum number of steps
+        if self.schedule.steps < self.min_steps_converge:
+            return False
 
         # in variable risk with risk adjustment, numbers are not strictly equal
         # but do get close and fairly stable; round to two digits before comparing

--- a/simulatingrisk/hawkdove/model.py
+++ b/simulatingrisk/hawkdove/model.py
@@ -1,7 +1,7 @@
-from enum import Enum
-from collections import deque
 import math
 import statistics
+from collections import deque
+from enum import Enum
 
 import mesa
 
@@ -216,7 +216,7 @@ class HawkDoveModel(mesa.Model):
         play_neighborhood=8,
         observed_neighborhood=8,
         hawk_odds=0.5,
-        random_play_odds=0.00,
+        random_play_odds=0.01,
     ):
         super().__init__()
         # check parameters for combinations that aren't allowed together

--- a/simulatingrisk/hawkdovemulti/app.py
+++ b/simulatingrisk/hawkdovemulti/app.py
@@ -28,6 +28,12 @@ jupyterviz_params_var.update(
             "values": HawkDoveMultipleRiskModel.risk_distribution_options,
             "description": "Distribution for initial risk attitudes",
         },
+        "include_endpoints": {
+            "label": "Include risk attitudes 0 and 9",
+            "type": "Checkbox",
+            "value": True,
+            "description": "Include 0/9 risk attitudes",
+        },
         "adjust_every": {
             "label": "Adjustment frequency (# rounds)",
             "type": "SliderInt",

--- a/simulatingrisk/hawkdovemulti/batch_run.py
+++ b/simulatingrisk/hawkdovemulti/batch_run.py
@@ -30,7 +30,7 @@ params = {
         "adjust_every": [2, 10, 20],
         "risk_distribution": HawkDoveMultipleRiskModel.risk_distribution_options,
         "adjust_payoff": HawkDoveMultipleRiskModel.supported_adjust_payoffs,
-        # random?
+        "random_play_odds": [0, 0.01, 0.1],
     },
     # specific scenarios to allow paired statistical tests
     "risk_adjust": {

--- a/simulatingrisk/hawkdovemulti/model.py
+++ b/simulatingrisk/hawkdovemulti/model.py
@@ -1,5 +1,6 @@
+import random
 import statistics
-from collections import Counter, deque
+from collections import Counter, defaultdict, deque
 from enum import IntEnum
 from functools import cached_property
 
@@ -62,11 +63,22 @@ class HawkDoveMultipleRiskAgent(HawkDoveAgent):
         # sort neighbors by points, highest points first
         # adapted from risky bet wealthiest neighbor
 
-        return sorted(
-            self.adjust_neighbors,
-            key=lambda x: getattr(x, self.compare_payoff_field),
-            reverse=True,
-        )[0]
+        # organize neighbors by score; use dict of list,
+        # since it's possible to have ties
+        neighbors_by_score = defaultdict(list)
+        best_payoff = 0
+        for neighbor in self.adjust_neighbors:
+            points = getattr(neighbor, self.compare_payoff_field)
+            best_payoff = max(best_payoff, points)
+            neighbors_by_score[points].append(neighbor)
+
+        # get the list of all neighbors with the best payoff
+        most_successful = neighbors_by_score[best_payoff]
+        # if there is only one, return it
+        if len(most_successful) == 1:
+            return most_successful[0]
+        # if one or more tied, choose randomly
+        return random.choice(most_successful)
 
     def adjust_risk(self):
         # look at neighbors

--- a/simulatingrisk/hawkdovemulti/model.py
+++ b/simulatingrisk/hawkdovemulti/model.py
@@ -193,6 +193,7 @@ class HawkDoveMultipleRiskModel(HawkDoveModel):
         adjust_every=10,
         adjust_neighborhood=None,
         adjust_payoff="recent",
+        include_endpoints=True,
         *args,
         **kwargs,
     ):
@@ -222,6 +223,11 @@ class HawkDoveMultipleRiskModel(HawkDoveModel):
                 f"Unsupported adjust payoff option '{adjust_payoff}'; "
                 + f"must be one of {adjust_payoffs_opts}"
             )
+
+        # if endpoints are not included, shift min/max risk attitude from 0-9 to 1-8
+        if not include_endpoints:
+            self.min_risk_level = 1
+            self.max_risk_level = 8
 
         # initialize a risk attitude generator based on configured distrbution
         # must be set before calling super for agent init
@@ -272,8 +278,8 @@ class HawkDoveMultipleRiskModel(HawkDoveModel):
             # values from two different normal distributions centered
             # around the beginning and end of our risk attitude range
             while True:
-                yield round(self.random.gauss(0, 1.5))
-                yield round(self.random.gauss(9, 1.5))
+                yield round(self.random.gauss(self.min_risk_level, 1.5))
+                yield round(self.random.gauss(self.max_risk_level, 1.5))
                 # NOTE: on smaller grids, using 0/9 makes it extremely
                 # unlikely to get mid-range risk values (4/5)
 

--- a/simulatingrisk/hawkdovemulti/model.py
+++ b/simulatingrisk/hawkdovemulti/model.py
@@ -405,11 +405,14 @@ class HawkDoveMultipleRiskModel(HawkDoveModel):
         a = self.recent_total_per_risk_level[0]
         b = self.recent_total_per_risk_level[1]
         changes = {}
-        # for each risk level, calculate the absolute difference
-        for rlevel, total in a.items():
-            changes[rlevel] = abs(total - b[rlevel])
-
-        return sum([val for val in changes.values()])
+        # for each risk level, calculate the absolute difference.
+        # check all risk levels, since when adjustment results in no
+        # agents in with particular risk attitude the counts may not match
+        for rlevel in range(self.min_risk_level, self.max_risk_level + 1):
+            # Counter returns zero for any missing items
+            changes[rlevel] = abs(a[rlevel] - b[rlevel])
+        # return the sum of changes across all risk levels
+        return sum(changes.values())
 
     def __getattr__(self, attr):
         # support dynamic properties for data collection on total by risk level

--- a/simulatingrisk/hawkdovemulti/model.py
+++ b/simulatingrisk/hawkdovemulti/model.py
@@ -175,6 +175,11 @@ class HawkDoveMultipleRiskModel(HawkDoveModel):
     risk_attitudes = "variable"
     agent_class = HawkDoveMultipleRiskAgent
 
+    #: minimum steps before model can converge
+    min_steps_converge = 50
+    #: higher minimum when risk adjustment is enabled
+    min_steps_adjusting = 300
+
     supported_risk_adjustments = (None, "adopt", "average")
     supported_adjust_payoffs = ("recent", "total")
     risk_distribution_options = (
@@ -217,6 +222,11 @@ class HawkDoveMultipleRiskModel(HawkDoveModel):
                 f"Unsupported risk adjustment '{risk_adjustment}'; "
                 + f"must be one of {risk_adjust_opts}"
             )
+
+        # update the minimum rounds for convergence when adjustment is enabled
+        if risk_adjustment is not None:
+            self.min_steps_converge = self.min_steps_adjusting
+
         if adjust_payoff not in self.supported_adjust_payoffs:
             adjust_payoffs_opts = ", ".join(self.supported_adjust_payoffs)
             raise ValueError(
@@ -365,9 +375,14 @@ class HawkDoveMultipleRiskModel(HawkDoveModel):
         if not self.risk_adjustment:
             return super().converged
 
+        # don't check for convergence until after the configured min step
+        # (duplicates base class logic since we otherwise override)
+        if self.schedule.steps < self.min_steps_converge:
+            return False
+
         # this simulation typically takes around 1000 rounds to converge,
         # so don't even bother checking until at least 50 rounds
-        return self.schedule.steps > max(self.adjust_round_n, 50) and (
+        return (
             self.num_agents_risk_changed == 0
             # NOTE: could adjust the threshold here
             or self.sum_risk_level_changes <= len(self.schedule.agents) * 0.07

--- a/tests/test_hawkdove.py
+++ b/tests/test_hawkdove.py
@@ -94,6 +94,29 @@ def test_model_single_risk_level():
         assert agent.risk_level == risk_level
 
 
+def test_model_converged():
+    risk_level = 3
+    model = HawkDoveSingleRiskModel(5, agent_risk_level=risk_level)
+
+    # before minimum number of steps, will always be false
+    model.schedule.steps = model.min_steps_converge - 1
+    assert not model.converged
+
+    model.schedule.steps = model.min_steps_converge + 1
+    # set min window smaller for testing purposes
+    model.min_window = 3
+    model.recent_rolling_percent_hawk = [0.49, 0.48, 0.50, 0.47]
+    assert not model.converged
+
+    # slight variation but all round to 0.48
+    model.recent_rolling_percent_hawk = [0.481, 0.482, 0.483, 0.480]
+    assert model.converged
+
+    # low rolling average but not past min steps
+    model.schedule.steps = model.min_steps_converge - 1
+    assert not model.converged
+
+
 def test_bad_neighborhood_size():
     with pytest.raises(ValueError):
         HawkDoveSingleRiskModel(3, play_neighborhood=3, agent_risk_level=6)

--- a/tests/test_hawkdove.py
+++ b/tests/test_hawkdove.py
@@ -95,8 +95,7 @@ def test_model_single_risk_level():
 
 
 def test_model_converged():
-    risk_level = 3
-    model = HawkDoveSingleRiskModel(5, agent_risk_level=risk_level)
+    model = HawkDoveSingleRiskModel(5, agent_risk_level=4)
 
     # before minimum number of steps, will always be false
     model.schedule.steps = model.min_steps_converge - 1
@@ -105,6 +104,7 @@ def test_model_converged():
     model.schedule.steps = model.min_steps_converge + 1
     # set min window smaller for testing purposes
     model.min_window = 3
+    # convergence is based on rolling average percent hawk
     model.recent_rolling_percent_hawk = [0.49, 0.48, 0.50, 0.47]
     assert not model.converged
 

--- a/tests/test_hawkdovemulti.py
+++ b/tests/test_hawkdovemulti.py
@@ -1,12 +1,12 @@
 import statistics
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
 from simulatingrisk.hawkdove.model import Play
 from simulatingrisk.hawkdovemulti.model import (
-    HawkDoveMultipleRiskModel,
     HawkDoveMultipleRiskAgent,
+    HawkDoveMultipleRiskModel,
     RiskState,
 )
 
@@ -213,6 +213,31 @@ def test_most_successful_neighbor():
         assert agent_total.most_successful_neighbor.points == 31
         # comparing by recent points
         assert agent_recent.most_successful_neighbor.recent_points == 13
+
+    # choose randomly when there is a tie
+    mock_neighbors = [
+        Mock(points=22, recent_points=1, id=1),
+        Mock(points=14, recent_points=9, id=2),
+        Mock(points=22, recent_points=8, id=3),
+        Mock(points=13, recent_points=9, id=4),
+    ]
+
+    with patch.object(HawkDoveMultipleRiskAgent, "adjust_neighbors", mock_neighbors):
+        # comparing by total points
+        assert agent_total.most_successful_neighbor.points == 22
+
+        # make a set to track best neighbors and run multiple times
+        # to ensure we get them both
+        best_neighbor = set()
+        recent_best = set()
+        for _ in range(10):
+            best_neighbor.add(agent_total.most_successful_neighbor.id)
+            recent_best.add(agent_recent.most_successful_neighbor.id)
+
+        # neighbors 1 and 3 both have 22 points - should see both if we check ten times
+        assert best_neighbor == {1, 3}
+        # neighbors 2 and 4 both have best recent points - should see both
+        assert recent_best == {2, 4}
 
 
 def test_compare_payoff():

--- a/tests/test_hawkdovemulti.py
+++ b/tests/test_hawkdovemulti.py
@@ -1,4 +1,5 @@
 import statistics
+from collections import Counter
 from unittest.mock import Mock, patch
 
 import pytest
@@ -62,6 +63,15 @@ def test_init_variable_risk_level():
     # when risk level is variable/random, agents should have different risk levels
     risk_levels = set([agent.risk_level for agent in model.schedule.agents])
     assert len(risk_levels) > 1
+
+
+def test_init_min_run_length():
+    model = HawkDoveMultipleRiskModel(5, risk_adjustment=None)
+    assert model.min_steps_converge == HawkDoveMultipleRiskModel.min_steps_converge
+
+    # higher minimum when adjustment is enabled
+    model = HawkDoveMultipleRiskModel(5, risk_adjustment="adopt")
+    assert model.min_steps_converge == HawkDoveMultipleRiskModel.min_steps_adjusting
 
 
 adjustment_testdata = [
@@ -175,6 +185,82 @@ def test_population_risk_category():
     model.schedule.agents = [Mock(risk_level=7), Mock(risk_level=8), Mock(risk_level=9)]
     del model.total_per_risk_level  #  reset cached property
     assert model.population_risk_category == RiskState.c12
+
+
+def test_model_converged():
+    model = HawkDoveMultipleRiskModel(5, risk_adjustment=None)
+
+    # non-adjusting case is the same logic as the base class
+
+    # before minimum number of steps, will always be false
+    model.schedule.steps = model.min_steps_converge - 1
+    assert not model.converged
+
+    model.schedule.steps = model.min_steps_converge + 1
+    # set min window smaller for testing purposes
+    model.min_window = 3
+    # convergence is based on rolling average percent hawk
+    model.recent_rolling_percent_hawk = [0.49, 0.48, 0.50, 0.47]
+    assert not model.converged
+
+    # adjustment converge logic is different
+    model = HawkDoveMultipleRiskModel(5, risk_adjustment="adopt")
+    # simulate no adjustments on last round
+    with patch.multiple(HawkDoveMultipleRiskModel, num_agents_risk_changed=0):
+        model.schedule.steps = model.min_steps_converge - 1
+        assert not model.converged
+
+        model.schedule.steps = model.min_steps_converge + 1
+        assert model.converged
+
+    # test convergence based on sum of risk level changes
+    with patch.multiple(
+        HawkDoveMultipleRiskModel, num_agents_risk_changed=5, sum_risk_level_changes=10
+    ):
+        assert not model.converged
+    # 5x5 grid = 25 agents; 7% = 1.75, so threshold is 1
+    with patch.multiple(
+        HawkDoveMultipleRiskModel, num_agents_risk_changed=5, sum_risk_level_changes=1
+    ):
+        assert model.converged
+
+        # convergence logic honors min steps
+        model.schedule.steps = model.min_steps_converge - 1
+        assert not model.converged
+
+
+def test_sum_risk_level_changes():
+    model = HawkDoveMultipleRiskModel(5, risk_adjustment="adopt")
+    # populate recent risk numbers from a sample run
+    model.recent_total_per_risk_level = [
+        Counter({0: 21, 2: 7, 3: 13, 4: 23, 7: 20, 8: 5, 9: 11}),
+        Counter({0: 22, 2: 7, 3: 13, 4: 20, 7: 21, 8: 5, 9: 12}),
+        #    1     0      0      3      1     0      1
+    ]
+    assert model.sum_risk_level_changes == 6
+
+    # handle case when there is not yet enough data
+    del model.sum_risk_level_changes  # clear cached property
+    del model.recent_total_per_risk_level[1]  # reduce to list of 1
+    assert model.sum_risk_level_changes is None
+
+    del model.sum_risk_level_changes  # clear cached property
+    model.recent_total_per_risk_level = []  # empty list
+    assert model.sum_risk_level_changes is None
+
+    # count when there is a mismatch in risk levels with counts
+    del model.sum_risk_level_changes  # clear cached property
+    # 4 is in a but not b
+    model.recent_total_per_risk_level = [
+        Counter({2: 7, 3: 13, 4: 2, 5: 20}),
+        Counter({2: 7, 3: 12, 5: 21}),
+        #   0      1     2      1
+    ]
+    assert model.sum_risk_level_changes == 4
+    del model.sum_risk_level_changes  # clear cached property
+    # not order dependent
+    reversed(model.recent_total_per_risk_level)
+    assert model.sum_risk_level_changes == 4
 
 
 def test_riskstate_label():

--- a/tests/test_hawkdovemulti.py
+++ b/tests/test_hawkdovemulti.py
@@ -36,6 +36,13 @@ def test_init():
     assert model.hawk_odds == 0.2
     assert model.play_neighborhood == 4
     assert model.adjust_neighborhood == 24
+    assert model.min_risk_level == 0
+    assert model.max_risk_level == 9
+
+    # initialize with risk attitude endpoints not included
+    model = HawkDoveMultipleRiskModel(grid_size=5, include_endpoints=False)
+    assert model.min_risk_level == 1
+    assert model.max_risk_level == 8
 
     # handle string none for solara app parameters
     model = HawkDoveMultipleRiskModel(5, risk_adjustment="none")
@@ -453,6 +460,18 @@ def test_get_risk_attitude_generator():
     next(risk_gen)
     model.random.gauss.assert_any_call(0, 1.5)
     model.random.gauss.assert_any_call(9, 1.5)
+
+    # confirm that bimodal risk attitude generator honors min/max risk attitudes
+    model = HawkDoveMultipleRiskModel(
+        3, include_endpoints=False, risk_distribution="bimodal"
+    )
+    model.random = Mock()
+    model.random.gauss.return_value = 3.2
+    risk_gen = model.get_risk_attitude_generator()
+    next(risk_gen)
+    next(risk_gen)
+    model.random.gauss.assert_any_call(1, 1.5)
+    model.random.gauss.assert_any_call(8, 1.5)
 
 
 def test_get_risk_attitude():


### PR DESCRIPTION
**Associated Issues:** 
- #95 
- #96 
- #97 
- #98
- #99 
- #100 
- #101 

### Changes in this PR
- Added a model parameter & logic for minimum steps before simulation can converge; set to 30 in the base module (single risk attitude), 50 for multiple risk attitudes with no adjustments, 300 for multiple risk attitude with adjustment
- Set random play odds to 0.01 by default and include in default batch parameters
- When there is a tie for most successful neighbor to emulate, choose randomly
- Add parameter to control whether to include extreme/irrational risk attitudes 0 and 9
- Fix possible bug in counting recent risk attitude changes by checking all possible values